### PR TITLE
AEMM-4157415 Build issue with Xcode-11 Beta version

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m
@@ -378,8 +378,13 @@ static NSString *stripFragment(NSString* url)
                 // Fix AEMM-4138205: decrement _loadCount when a frame fails to load
                 _loadCount -= 1;
             } else {
-                fireCallback = YES;
-                _state = STATE_CANCELLED;
+                // Porting changes viewer-ios to aemm-ios repo
+                // Fix AEMM-4155816: don't enter STATE_CANCELLED if it is not the main document that fails to load
+                if([self isMainDocumentFail:error on:webView])
+                {
+                    fireCallback = YES;
+                    _state = STATE_CANCELLED;
+                }
                 _loadCount -= 1;
             }
             break;
@@ -396,6 +401,11 @@ static NSString *stripFragment(NSString* url)
     if (fireCallback && [_delegate respondsToSelector:@selector(webView:didFailLoadWithError:)]) {
         [_delegate webView:webView didFailLoadWithError:error];
     }
+}
+
+-(BOOL) isMainDocumentFail:(NSError*)error on:(UIWebView*)webView
+{
+    return [[error.userInfo valueForKey:@"NSErrorFailingURLKey"] isEqual:webView.request.mainDocumentURL];
 }
 
 @end

--- a/bin/templates/scripts/cordova/lib/build.js
+++ b/bin/templates/scripts/cordova/lib/build.js
@@ -33,7 +33,6 @@ var projectName = null;
 
 // These are regular expressions to detect if the user is changing any of the built-in xcodebuildArgs
 var buildFlagMatchers = {
-    'xcconfig' : /^\-xcconfig\s*(.*)$/,
     'project' : /^\-project\s*(.*)/,
     'archs' : /^(ARCHS=.*)/,
     'target' : /^\-target\s*(.*)/,
@@ -173,7 +172,6 @@ function getXcodeArgs(projectName, projectPath, configuration, isDevice, buildFl
 
     if (isDevice) {
         options = [
-            '-xcconfig', customArgs.xcconfig || path.join(__dirname, '..', 'build-' + configuration.toLowerCase() + '.xcconfig'),
             '-project',  customArgs.project || projectName + '.xcodeproj',
             customArgs.archs || 'ARCHS=armv7 arm64',
             '-target', customArgs.target || projectName,
@@ -187,7 +185,6 @@ function getXcodeArgs(projectName, projectPath, configuration, isDevice, buildFl
         ];
     } else { // emulator
         options = [
-            '-xcconfig', customArgs.xcconfig || path.join(__dirname, '..', 'build-' + configuration.toLowerCase() + '.xcconfig'),
             '-project', customArgs.project || projectName + '.xcodeproj',
             customArgs.archs || 'ARCHS=x86_64 i386',
             '-target', customArgs.target || projectName,

--- a/bin/templates/scripts/cordova/lib/copy-www-build-step.js
+++ b/bin/templates/scripts/cordova/lib/copy-www-build-step.js
@@ -51,9 +51,6 @@ try {
 // Code signing files must be removed or else there are
 // resource signing errors.
 shell.rm('-rf', dstWwwDir);
-shell.rm('-rf', path.join(dstDir, '_CodeSignature'));
-shell.rm('-rf', path.join(dstDir, 'PkgInfo'));
-shell.rm('-rf', path.join(dstDir, 'embedded.mobileprovision'));
 
 // Copy www dir recursively
 var code;


### PR DESCRIPTION
Commit includes: 

AEMM-4157415: Changes a fix in aemm-ios repo instead of the viewer-io…s in file CordovaLib/Classes/Private/Plugins/CDVUIWebViewEngine/CDVUIWebViewDelegate.m

AEMM-4157415: Removed code signing code in file bin/templates/scripts/cordova/lib/copy-www-build-step.js, no need to sign cordova project
AEMM-4157415: Removed xcconfig build flag from file bin/templates/scripts/cordova/lib/build.js